### PR TITLE
Support a gTLD on its own in domainConstant.

### DIFF
--- a/transport_security_state_static_generate.go
+++ b/transport_security_state_static_generate.go
@@ -550,9 +550,13 @@ func toDNS(s string) (string, int) {
 func domainConstant(s string) string {
 	labels := strings.Split(s, ".")
 	gtld := strings.ToUpper(labels[len(labels)-1])
-	domain := strings.Replace(strings.ToUpper(labels[len(labels)-2]), "-", "_", -1)
 
-	return fmt.Sprintf("DOMAIN_%s_%s", domain, gtld)
+	if len(labels) == 1 {
+		return fmt.Sprintf("DOMAIN_%s", gtld)
+	} else {
+		domain := strings.Replace(strings.ToUpper(labels[len(labels)-2]), "-", "_", -1)
+		return fmt.Sprintf("DOMAIN_%s_%s", domain, gtld)
+	}
 }
 
 type pinsetData struct {


### PR DESCRIPTION
 We need this now that all of `.google` is preloaded.