### PR TITLE
Remove invalid C++ variable name chars before checking cert name against common name.

### DIFF
--- a/transport_security_state_static_generate.go
+++ b/transport_security_state_static_generate.go
@@ -345,10 +345,11 @@ func matchNames(name, v string) error {
 	if len(firstWord) == 0 {
 		return errors.New("first word of certificate name is empty")
 	}
+	firstWord = regexp.MustCompile("[^A-Za-z0-9_]+").ReplaceAllString(firstWord, "")
 	firstWord = strings.ToLower(firstWord)
 	lowerV := strings.ToLower(v)
 	if !strings.HasPrefix(lowerV, firstWord) {
-		return errors.New("the first word of the certificate name isn't a prefix of the variable name")
+		return fmt.Errorf("the first word of the certificate name (%s) isn't a prefix of the variable name (%s)", firstWord, lowerV)
 	}
 
 	for i, word := range words {


### PR DESCRIPTION
Also, print a more useful error in case of mismatch.

For https://codereview.chromium.org/1473243005